### PR TITLE
Add patch information into hyperparameters files

### DIFF
--- a/bin/analyse_attribution.py
+++ b/bin/analyse_attribution.py
@@ -397,7 +397,7 @@ def main():
 
     in_channels = hyperparameters["in_channels"]
     out_channels = hyperparameters["out_channels"]
-    sw_shape = hyperparameters["patch_size"]
+    sw_shape = hyperparameters["input_shape"]
 
     # Load the image and its associated ground-truth
     I_x, meta = LoadImage(image_only=False, ensure_channel_first=True)(

--- a/bin/compute_attribution.py
+++ b/bin/compute_attribution.py
@@ -125,8 +125,8 @@ def main():
     in_channels     = hyperparameters["in_channels"]
     out_channels    = hyperparameters["out_channels"]
 
-    sw_shape    = [in_channels] + hyperparameters["patch_size"] # All dimensions should be specified
-    sw_overlap  = [0] + [hyperparameters["patch_overlap"]] * len(hyperparameters["patch_size"])
+    sw_shape    = [in_channels] + hyperparameters["input_shape"] # All dimensions should be specified
+    sw_overlap  = [0] + [hyperparameters["patch_overlap"]] * len(hyperparameters["input_shape"])
 
     # Image
     I, meta = LoadImage(image_only=False, ensure_channel_first=True)(x_path)

--- a/bin/eval.py
+++ b/bin/eval.py
@@ -245,7 +245,7 @@ def main():
 
     # Prepare the inferer
     sw_batch_size   = hyperparameters["batch_size"]
-    sw_shape        = hyperparameters["patch_size"]
+    sw_shape        = hyperparameters["input_shape"]
     sw_overlap      = hyperparameters["patch_overlap"]
 
     inferer = SlidingWindowInferer(

--- a/bin/infer.py
+++ b/bin/infer.py
@@ -243,7 +243,7 @@ def main():
 
     # Prepare the inferer
     sw_batch_size = hyperparameters["batch_size"]
-    sw_shape = hyperparameters["patch_size"]
+    sw_shape = hyperparameters["input_shape"]
     sw_overlap = hyperparameters["patch_overlap"]
 
     inferer = SlidingWindowInferer(

--- a/bin/train.py
+++ b/bin/train.py
@@ -116,7 +116,7 @@ def fit(model: Module, train_loader: DataLoader, val_loader: DataLoader, hyperpa
 
     sw_batch_size = hyperparameters["batch_size"] # How many sliding windows processed at the same time
     is_patch      = hyperparameters["patch"]
-    sw_patch_size = hyperparameters["patch_size"]
+    sw_patch_size = hyperparameters["input_shape"]
     
     val_metric = DiceMetric(include_background=include_background, reduction="mean")
 
@@ -285,7 +285,7 @@ def main():
 
     # Define variables
     batch_size      = hyperparameters["batch_size"]
-    input_shape     = hyperparameters["patch_size"]
+    input_shape     = hyperparameters["input_shape"]
     spatial_dims    = len(input_shape)
     is_patch        = hyperparameters["patch"]
     in_channels     = hyperparameters["in_channels"]

--- a/bin/train.py
+++ b/bin/train.py
@@ -115,6 +115,7 @@ def fit(model: Module, train_loader: DataLoader, val_loader: DataLoader, hyperpa
     val_interval = 1
 
     sw_batch_size = hyperparameters["batch_size"] # How many sliding windows processed at the same time
+    is_patch      = hyperparameters["patch"]
     sw_patch_size = hyperparameters["patch_size"]
     
     val_metric = DiceMetric(include_background=include_background, reduction="mean")
@@ -198,13 +199,12 @@ def fit(model: Module, train_loader: DataLoader, val_loader: DataLoader, hyperpa
 
                     val_inputs, val_labels = val_data["img"].to(device), val_data["seg"].to(device)
 
-                    if np.unique(sw_patch_size) == -1:
-                        val_outputs = SimpleInferer()(val_inputs, model)
-                    else:
-
+                    if is_patch:
                         val_outputs = sliding_window_inference(
                             val_inputs, sw_patch_size, sw_batch_size, model
                         )
+                    else:
+                        val_outputs = SimpleInferer()(val_inputs, model)
 
                     val_loss = loss_function(val_outputs, val_labels) # Compute the validation loss for current iteration
                     logger.debug(f"Current val loss : {val_loss.item()}")
@@ -287,6 +287,7 @@ def main():
     batch_size      = hyperparameters["batch_size"]
     input_shape     = hyperparameters["patch_size"]
     spatial_dims    = len(input_shape)
+    is_patch        = hyperparameters["patch"]
     in_channels     = hyperparameters["in_channels"]
     out_channels    = hyperparameters["out_channels"]
     logger.debug(f"Input channels : {in_channels} | Output channels : {out_channels}")
@@ -301,7 +302,8 @@ def main():
         train_dataset_path,
         val_dataset_path,
         input_shape,
-        batch_size,
+        is_patch=is_patch,
+        batch_size=batch_size,
     )
 
     # Create the model

--- a/resources/default_hyperparameters.json
+++ b/resources/default_hyperparameters.json
@@ -3,6 +3,7 @@
     "batch_size": 16,
     "in_channels": 1,
     "out_channels": 1,
+    "patch": true,
     "patch_size": [64, 64, 64],
     "patch_overlap": 0.25,
     "lr": 0.0001

--- a/resources/default_hyperparameters.json
+++ b/resources/default_hyperparameters.json
@@ -4,7 +4,7 @@
     "in_channels": 1,
     "out_channels": 1,
     "patch": true,
-    "patch_size": [64, 64, 64],
+    "input_shape": [64, 64, 64],
     "patch_overlap": 0.25,
     "lr": 0.0001
 }

--- a/resources/ohe_hyperparameters.json
+++ b/resources/ohe_hyperparameters.json
@@ -3,6 +3,7 @@
     "batch_size": 16,
     "in_channels": 1,
     "out_channels": 2,
+    "patch": true,
     "patch_size": [64, 64, 64],
     "patch_overlap": 0.25,
     "lr": 0.0001

--- a/resources/ohe_hyperparameters.json
+++ b/resources/ohe_hyperparameters.json
@@ -4,7 +4,7 @@
     "in_channels": 1,
     "out_channels": 2,
     "patch": true,
-    "patch_size": [64, 64, 64],
+    "input_shape": [64, 64, 64],
     "patch_overlap": 0.25,
     "lr": 0.0001
 }

--- a/resources/whole_volume_hyperparameters.json
+++ b/resources/whole_volume_hyperparameters.json
@@ -4,7 +4,7 @@
     "in_channels": 1,
     "out_channels": 1,
     "patch": false,
-    "patch_size": [-1, -1, -1],
+    "input_shape": [-1, -1, -1],
     "patch_overlap": 0.25,
     "lr": 0.0001
 }

--- a/xai-vesselnet/datasets/instanciate_dataset.py
+++ b/xai-vesselnet/datasets/instanciate_dataset.py
@@ -51,7 +51,7 @@ def instanciate_image_dataset(data_path: str, image_only: bool = True, transform
 
 
 def create_training_loaders(
-    csv_train_path: str, csv_val_path: str, input_size: tuple, batch_size=16
+    csv_train_path: str, csv_val_path: str, input_size: tuple, is_patch: bool, batch_size=16
 ) -> tuple[DataLoader]:
     """
     Instantiate patch loaders used in the training pipeline (train, validation) from CSV files.
@@ -64,6 +64,7 @@ def create_training_loaders(
         csv_train_path: path to CSV file containing training data paths.
         csv_val_path: path to CSV file containing validation data paths.
         input_size: size of the patches
+        is_patch: indicates whether or not to split the data into patches
         batch_size: batch size. Defaults to 16.
 
     Notes:
@@ -75,7 +76,7 @@ def create_training_loaders(
 
     """
 
-    if np.unique(input_size) != -1:
+    if is_patch:
         train_ds = instanciate_image_dataset(csv_train_path)
         val_ds = instanciate_image_dataset(csv_val_path)
 


### PR DESCRIPTION
 - Hyperparameters files now integrate the nature of data using the new "patch" variable.
 - Use "patch" information to adapt the training
 - Rename "patch_size" hyperparam's variable into "input_shape" as code now supports whole volume training